### PR TITLE
Upgrade to latest Ruby version: 2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.4.1'
+ruby '2.5.1'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
Resolve #15 

The file `.ruby-version`, ignored by git, is necessary to be updated too.

More info:
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/