### PR TITLE
Add association between editions and packagings

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -45,11 +45,15 @@ class EditionsController < ApplicationController
   private
 
   def edition_params
-    params.require(:edition).permit(:name, :distributor_id, :country_code, :release_date, format_params)
+    params.require(:edition).permit(:name, :distributor_id, :country_code, :release_date, format_params, packaging_params)
   end
 
   def format_params
     { formats_attributes: [:id, :format_id, :number_of_discs, :_destroy] }
+  end
+
+  def packaging_params
+    { packagings_attributes: [:id, :packaging_id, :_destroy] }
   end
 
   def find_edition

--- a/app/forms/edition_form.rb
+++ b/app/forms/edition_form.rb
@@ -18,7 +18,7 @@ class EditionForm
   #
   # @return [Array] attributes of the model and name of its associations
   def self.edition_attributes
-    Edition.column_names + Edition.reflections.keys + [:formats_attributes]
+    Edition.column_names + Edition.reflections.keys + [:formats_attributes, :packagings_attributes]
   end
 
   # Used to retrieve all kinds of naming-related information
@@ -67,6 +67,10 @@ class EditionForm
 
   def edition_formats
     @edition_formats ||= Format.order(:name)
+  end
+
+  def edition_packagings
+    @edition_packagings ||= Packaging.order(:name)
   end
 
   private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,10 +1,12 @@
 class Edition < ApplicationRecord
   belongs_to :distributor
   has_many :formats, inverse_of: :edition, class_name: 'EditionFormat', dependent: :destroy
+  has_many :packagings, inverse_of: :edition, class_name: 'EditionPackaging', dependent: :destroy
   accepts_nested_attributes_for :formats, allow_destroy: true
+  accepts_nested_attributes_for :packagings, allow_destroy: true
 
   validates :name, :distributor_id, :country_code, :release_date, presence: true
-  validates :formats, presence: true, on: :update
+  validates :formats, :packagings, presence: true, on: :update
 
   delegate :name, to: :distributor, prefix: true
 end

--- a/app/models/edition_packaging.rb
+++ b/app/models/edition_packaging.rb
@@ -1,0 +1,21 @@
+class EditionPackaging < ApplicationRecord
+  belongs_to :edition
+  belongs_to :packaging
+
+  validates :packaging_id, :edition_id, presence: true
+  validates :packaging_id, uniqueness: { scope: :edition_id }, unless: :same_packaging_is_marked_for_destruction?
+
+  delegate :name, to: :packaging
+
+  private
+
+  def same_packaging_is_marked_for_destruction?
+    return if edition.nil?
+
+    same_packaging = edition.packagings.find { |f| f.packaging_id == packaging_id }
+
+    return if same_packaging.nil?
+
+    same_packaging.marked_for_destruction?
+  end
+end

--- a/app/models/packaging.rb
+++ b/app/models/packaging.rb
@@ -1,3 +1,6 @@
 class Packaging < ApplicationRecord
+  has_many :edition_packagings
+  has_many :editions, through: :edition_packagings
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -16,6 +16,12 @@ class EditionPresenter < BasePresenter
     edition.formats.map { |format| [format.number_of_discs, format.name].join(' ') }.join(', ')
   end
 
+  def packagings
+    return 'Not specified' if edition.packagings.empty?
+
+    edition.packagings.map(&:name).join(', ')
+  end
+
   def destroy
     link_to 'Delete', edition_path(edition), method: :delete, data: { confirm: 'Are you sure?' }
   end

--- a/app/views/editions/_edition.html.slim
+++ b/app/views/editions/_edition.html.slim
@@ -5,4 +5,5 @@
     td= edition_presenter.country
     td= edition.release_date
     td= edition_presenter.formats
+    td= edition_presenter.packagings
     td= edition_presenter.destroy

--- a/app/views/editions/_packaging_fields.html.slim
+++ b/app/views/editions/_packaging_fields.html.slim
@@ -1,0 +1,8 @@
+.nested-fields
+  .field
+    = f.label :packaging_id
+    br
+    = f.select :packaging_id, options_from_collection_for_select(form.edition_packagings, :id, :name, f.object.packaging_id),
+      include_blank: 'Select a packaging'
+
+    = link_to_remove_association 'Remove packaging', f

--- a/app/views/editions/edit.html.slim
+++ b/app/views/editions/edit.html.slim
@@ -1,13 +1,17 @@
 h2 Edit Edition
 
 == render 'form', form: @form do |f|
-  h3 Formats
-
   #formats
     = f.fields_for :formats do |format|
       = render 'format_fields', f: format, form: @form
     .links
       = link_to_add_association 'Add format', f, :formats, render_options: { locals: { form: @form } }
+
+  #packagings
+    = f.fields_for :packagings do |packaging|
+      = render 'packaging_fields', f: packaging, form: @form
+    .links
+      = link_to_add_association 'Add packaging', f, :packagings, render_options: { locals: { form: @form } }
 
 h3 Options
 

--- a/app/views/editions/index.html.slim
+++ b/app/views/editions/index.html.slim
@@ -8,6 +8,7 @@ table
       th Country
       th Release date
       th Formats
+      th Packagings
       th
   tbody
     = render @dashboard.editions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  resources :edition_formats
   resources :distributors
   resources :editions
   resources :formats

--- a/db/migrate/20180603114205_create_edition_packagings.rb
+++ b/db/migrate/20180603114205_create_edition_packagings.rb
@@ -1,0 +1,8 @@
+class CreateEditionPackagings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :edition_packagings do |t|
+      t.references :edition, foreign_key: true
+      t.references :packaging, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623213630) do
+ActiveRecord::Schema.define(version: 2018_06_03_114205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,13 @@ ActiveRecord::Schema.define(version: 20170623213630) do
     t.bigint "format_id"
     t.index ["edition_id"], name: "index_edition_formats_on_edition_id"
     t.index ["format_id"], name: "index_edition_formats_on_format_id"
+  end
+
+  create_table "edition_packagings", force: :cascade do |t|
+    t.bigint "edition_id"
+    t.bigint "packaging_id"
+    t.index ["edition_id"], name: "index_edition_packagings_on_edition_id"
+    t.index ["packaging_id"], name: "index_edition_packagings_on_packaging_id"
   end
 
   create_table "editions", force: :cascade do |t|
@@ -61,6 +68,8 @@ ActiveRecord::Schema.define(version: 20170623213630) do
 
   add_foreign_key "edition_formats", "editions"
   add_foreign_key "edition_formats", "formats"
+  add_foreign_key "edition_packagings", "editions"
+  add_foreign_key "edition_packagings", "packagings"
   add_foreign_key "editions", "distributors"
   add_foreign_key "regions", "formats"
 end

--- a/spec/factories/edition_packagings.rb
+++ b/spec/factories/edition_packagings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :edition_packaging do
+    edition
+    packaging
+  end
+end

--- a/spec/factories/packagings.rb
+++ b/spec/factories/packagings.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :packaging do
-    name { Faker::Lorem.word.capitalize }
+    name { Faker::Lorem.unique.word.capitalize }
   end
 end

--- a/spec/models/edition_packaging_spec.rb
+++ b/spec/models/edition_packaging_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe EditionPackaging, type: :model do
+  it { is_expected.to belong_to :edition }
+  it { is_expected.to belong_to :packaging }
+
+  it { is_expected.to validate_presence_of :packaging_id }
+  it { is_expected.to validate_presence_of :edition_id }
+
+  context 'validates uniqueness of :packaging_id within the scope of :edition_id' do
+    let(:edition) { create(:edition) }
+    let(:digipak) { create(:packaging, name: 'Digipak') }
+
+    it 'not including any error when record is not persisted' do
+      edition_packaging = described_class.new
+
+      edition_packaging.valid?
+
+      expect(edition_packaging.errors[:packaging_id]).to_not include 'has already been taken'
+    end
+
+    it 'not including any error when edition does not have packagings associated' do
+      edition.packagings << create(:edition_packaging, packaging: digipak)
+
+      edition.packagings.first.valid?
+
+      expect(edition.packagings.first.errors[:packaging_id]).to_not include 'has already been taken'
+    end
+
+    it 'not including any error when same packaging has been marked for destruction' do
+      edition.packagings << create(:edition_packaging, packaging: digipak)
+      edition.packagings << build(:edition_packaging, packaging: digipak)
+
+      edition.packagings.first.mark_for_destruction
+      edition.packagings.last.valid?
+
+      expect(edition.packagings.last.errors[:packaging_id]).to_not include 'has already been taken'
+    end
+
+    it 'including error when same packaging has already been associated to edition' do
+      edition.packagings << create(:edition_packaging, packaging: digipak)
+      edition.packagings << build(:edition_packaging, packaging: digipak)
+
+      edition.packagings.last.valid?
+
+      expect(edition.packagings.last.errors[:packaging_id]).to include 'has already been taken'
+    end
+  end
+
+  it { is_expected.to delegate_method(:name).to :packaging }
+end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -3,13 +3,16 @@ require 'rails_helper'
 RSpec.describe Edition, type: :model do
   it { is_expected.to belong_to :distributor }
   it { is_expected.to have_many(:formats).class_name('EditionFormat').dependent :destroy }
+  it { is_expected.to have_many(:packagings).class_name('EditionPackaging').dependent :destroy }
   it { is_expected.to accept_nested_attributes_for(:formats).allow_destroy(true) }
+  it { is_expected.to accept_nested_attributes_for(:packagings).allow_destroy(true) }
 
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_presence_of :distributor_id }
   it { is_expected.to validate_presence_of :country_code }
   it { is_expected.to validate_presence_of :release_date }
   it { is_expected.to validate_presence_of(:formats).on(:update) }
+  it { is_expected.to validate_presence_of(:packagings).on(:update) }
 
   it { is_expected.to delegate_method(:name).to(:distributor).with_prefix }
 end

--- a/spec/models/packaging_spec.rb
+++ b/spec/models/packaging_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Packaging, type: :model do
+  it { is_expected.to have_many :edition_packagings }
+  it { is_expected.to have_many(:editions).through :edition_packagings }
+
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 end

--- a/spec/requests/editions_spec.rb
+++ b/spec/requests/editions_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'Editions', type: :request do
   describe '#update' do
     let(:edition) { create(:edition, name: 'Back To The Future Trilogy') }
     let(:dvd)     { create(:format, name: 'DVD') }
+    let(:digipak) { create(:packaging, name: 'Digipak') }
 
     it 'instantiates form object' do
       expect(EditionForm).to receive(:new).and_call_original
@@ -124,6 +125,12 @@ RSpec.describe 'Editions', type: :request do
                 'number_of_discs' => 2,
                 '_destroy'        => false
               }
+            },
+            packagings_attributes: {
+              654321 => {
+                'packaging_id' => digipak.id,
+                '_destroy'     => false
+              }
             }
           }
         }
@@ -137,6 +144,8 @@ RSpec.describe 'Editions', type: :request do
           edition.name
         }.from('Back To The Future Trilogy').to('Back To The Future Trilogy CE').and change {
           edition.formats.count
+        }.from(0).to(1).and change {
+          edition.packagings.count
         }.from(0).to 1
       end
 


### PR DESCRIPTION
Resolve #8 

- Edition accepts nested attributes for packagings.
- Packaging must be unique within the scope of an edition, unless existing one
  is marked for destruction.

Most of the hard work was done and included in PR #19.